### PR TITLE
feat: PC-3186 | storage class parameter

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -75,6 +75,8 @@ import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   // S3 Group
+  public static final String S3_STORAGE_CLASS = "s3.storage.class";
+
   public static final String S3_BUCKET_CONFIG = "s3.bucket.name";
 
   public static final String S3_OBJECT_TAGGING_CONFIG = "s3.object.tagging";
@@ -260,6 +262,17 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.LONG,
           "S3 Bucket"
+      );
+
+      configDef.define(
+          S3_STORAGE_CLASS,
+          Type.STRING,
+          Importance.LOW,
+          "The storage class to use for new objects.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 Storage Class"
       );
 
       configDef.define(
@@ -712,6 +725,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public String getBucketName() {
     return getString(S3_BUCKET_CONFIG);
+  }
+
+  public String getStorageClass() {
+    return getString(S3_STORAGE_CLASS);
   }
 
   public String getSsea() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -76,6 +76,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   // S3 Group
   public static final String S3_STORAGE_CLASS = "s3.storage.class";
+  public static final String S3_STORAGE_CLASS_DEFAULT = "STANDARD";
 
   public static final String S3_BUCKET_CONFIG = "s3.bucket.name";
 
@@ -267,6 +268,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       configDef.define(
           S3_STORAGE_CLASS,
           Type.STRING,
+          S3_STORAGE_CLASS_DEFAULT,
           Importance.LOW,
           "The storage class to use for new objects.",
           group,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -53,6 +53,7 @@ public class S3OutputStream extends PositionOutputStream {
   private final AmazonS3 s3;
   private final S3SinkConnectorConfig connectorConfig;
   private final String bucket;
+  private final String storageClass;
   private final String key;
   private final String ssea;
   private final SSECustomerKey sseCustomerKey;
@@ -72,6 +73,7 @@ public class S3OutputStream extends PositionOutputStream {
     this.s3 = s3;
     this.connectorConfig = conf;
     this.bucket = conf.getBucketName();
+    this.storageClass = conf.getStorageClass();
     this.key = key;
     this.ssea = conf.getSsea();
     final String sseCustomerKeyConfig = conf.getSseCustomerKey();
@@ -204,7 +206,8 @@ public class S3OutputStream extends PositionOutputStream {
         bucket,
         key,
         newObjectMetadata()
-    ).withCannedACL(cannedAcl);
+    ).withCannedACL(cannedAcl)
+    .withStorageClass(storageClass);
 
     if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
         && StringUtils.isNotBlank(sseKmsKeyId)) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -207,7 +207,7 @@ public class S3OutputStream extends PositionOutputStream {
         key,
         newObjectMetadata()
     ).withCannedACL(cannedAcl)
-    .withStorageClass(storageClass);
+        .withStorageClass(storageClass);
 
     if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
         && StringUtils.isNotBlank(sseKmsKeyId)) {


### PR DESCRIPTION
This PR adds s3 storage class as one of the configurations for the S3 sink connector. The storage class in the config object is used in the upload operations.

Jira Ticket: https://peak-bi.atlassian.net/browse/PC-3186